### PR TITLE
Inherit font with Callout

### DIFF
--- a/src/annotations/Callout.tsx
+++ b/src/annotations/Callout.tsx
@@ -64,7 +64,7 @@ export const callout: AnnotationHandler = {
 						}}
 					/>
 					{codeblock ? (
-						<Pre code={codeblock} style={{margin: 0}} />
+						<Pre code={codeblock} style={{margin: 0, fontFamily: inherit}} />
 					) : (
 						annotation.data.children || annotation.query
 					)}

--- a/src/annotations/Callout.tsx
+++ b/src/annotations/Callout.tsx
@@ -64,7 +64,7 @@ export const callout: AnnotationHandler = {
 						}}
 					/>
 					{codeblock ? (
-						<Pre code={codeblock} style={{margin: 0, fontFamily: inherit}} />
+						<Pre code={codeblock} style={{margin: 0, fontFamily: 'inherit'}} />
 					) : (
 						annotation.data.children || annotation.query
 					)}


### PR DESCRIPTION
# Changes

adds an inherit fontFamily to the Callout.tsx pre element.

# Why

Without it, the Callout will default to the monospace font and not use the Font (Roboto Mono in this case).