### PR TITLE
chore(docs): update README to use npm for build instead of bun

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ npm run build
 **Upgrade Remotion**
 
 ```console
-bun run upgrade
+npm run upgrade
 ```
 
 ## More examples


### PR DESCRIPTION
It makes more sense to use npm for the build as well if npm is used throughout the entire readme.