### PR TITLE
update codehike to 1.0.4 (was 1.0.0-beta.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@remotion/google-fonts": "^4.0.0",
     "@remotion/studio": "^4.0.0",
     "@remotion/layout-utils": "^4.0.0",
-    "codehike": "1.0.0-beta.2",
+    "codehike": "1.0.4",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "remotion": "^4.0.0",


### PR DESCRIPTION
I believe this is the latest stable version, according to https://github.com/code-hike/codehike/releases

I was running into an issue with the `-beta.2` version where I couldn't get it to add syntax highlighting to Kotlin code. But it works with `1.0.4`.